### PR TITLE
[WEBSITE-9] Find a Specialist not picking up group email for Academic Discipline taxonomy

### DIFF
--- a/src/templates/specialist.js
+++ b/src/templates/specialist.js
@@ -565,6 +565,8 @@ export const query = graphql`
           id
           name
           __typename
+          field_group_email
+          field_brief_group_description
           relationships {
             field_synonym {
               ...specialistsSynonym


### PR DESCRIPTION
Categories that fall directly under the `Academic Discipline` taxonomy and have group emails (e.g. [Psychology](https://cms.lib.umich.edu/taxonomy/term/329/edit) and [Sociology](https://cms.lib.umich.edu/taxonomy/term/335/edit)) were defaulting to Ask a Librarian. `field_group_email` and `field_brief_group_description` were missing from `graphQL`, but have now been added.