### PR TITLE
remove padding between index panel and aside layout

### DIFF
--- a/src/components/aside-layout.js
+++ b/src/components/aside-layout.js
@@ -76,6 +76,10 @@ export const TemplateSide = ({ children, contentSide = 'left', ...rest }) => {
                 }),
             paddingBottom: 0
           },
+          '[data-aside-layout]:has(+ [data-panel]) &': {
+            marginBottom: 0,
+            paddingBottom: 0
+          },
           borderBottom: `solid 1px var(--color-neutral-100)`,
           marginBottom: SPACING['2XL'],
           paddingBottom: SPACING['2XL']

--- a/src/components/aside-layout.js
+++ b/src/components/aside-layout.js
@@ -32,10 +32,10 @@ export const Template = ({
                   gridTemplateAreas: `"side content"`,
                   gridTemplateColumns: `calc(${asWidth}) 1fr`
                 }),
-            paddingBottom: SPACING['3XL'],
             '[data-aside-layout]:has(+ [data-panel]) > &': {
               paddingBottom: '0'
-            }
+            },
+            paddingBottom: SPACING['3XL']
           }
         }}
         {...rest}

--- a/src/components/aside-layout.js
+++ b/src/components/aside-layout.js
@@ -11,7 +11,7 @@ export const Template = ({
   const asWidth = asideWidth ? asideWidth : '21rem';
 
   return (
-    <Margins>
+    <Margins data-aside-layout>
       <div
         css={{
           '[data-panel-margins], [data-panel]': {
@@ -32,7 +32,10 @@ export const Template = ({
                   gridTemplateAreas: `"side content"`,
                   gridTemplateColumns: `calc(${asWidth}) 1fr`
                 }),
-            paddingBottom: SPACING['3XL']
+            paddingBottom: SPACING['3XL'],
+            '[data-aside-layout]:has(+ [data-panel]) > &': {
+              paddingBottom: '0'
+            }
           }
         }}
         {...rest}

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -37,6 +37,11 @@ const PanelTemplate = ({ title, children, shaded, headingCss, ...rest }) => {
           borderBottom: shaded ? 'none' : `solid 1px var(--color-neutral-100)`,
           paddingBottom: SPACING['3XL']
         },
+        '[data-aside-layout] + &': {
+          [MEDIA_QUERIES.S]: {
+            paddingTop: '0'
+          }
+        },
         background: shaded ? 'var(--color-blue-100)' : '',
         paddingBottom: SPACING.XL,
         paddingTop: SPACING.XL,


### PR DESCRIPTION
# Overview
Padding fighting between CA body and full-width card template ([see staging](https://staging.lib.umich.edu/collections/collecting-areas/special-collections/screen-arts-mavericks-and-makers)).

We haven't ever used a full-width card template after a CA body template, so this is a new issue.

The fix here is to add some conditional css to the templates. The conditional css checks if the `data-aside-layout` has a `data-panel` and will remove the padding (on desktop and mobile) if it does.

> This pull request fixes [WEBSITE-225](https://mlit.atlassian.net/jira/software/projects/WEBSITE/boards/27?selectedIssue=WEBSITE-225).

> [!NOTE]
> This page is currently only on staging. To see the results you may need to switch your local branch's cms to staging in `gatsby-config`.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari (the assignee was not able to test the pull request in this browser)
  - [x] Edge 
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
