### PR TITLE
Update netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  ignore = "exit 0"
+  ignore = "exit 1"
 [[headers]]
   for = "/*"
   [headers.values]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  ignore = "exit 1"
+  command = ""
 [[headers]]
   for = "/*"
   [headers.values]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
   publish = "public"
+  ignore = "exit 0"
 [[headers]]
   for = "/*"
   [headers.values]


### PR DESCRIPTION
# Overview
This pull request makes a small change to the `netlify.toml` configuration file by setting the `build.command` to an empty string, which disables any build command during deployment.
